### PR TITLE
feat: FRED fetcher

### DIFF
--- a/fetchers/fred.py
+++ b/fetchers/fred.py
@@ -1,0 +1,64 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FRED_KEY = os.getenv("FRED_API_KEY")
+BASE = "https://api.stlouisfed.org/fred/series/observations"
+
+# Series IDs from PRD §6, signal names from PRD §7.1 — both team-confirmed.
+SERIES = {
+    "30-yr mortgage rate": "MORTGAGE30US",
+    "federal funds rate": "FEDFUNDS",
+    "10-yr Treasury yield": "DGS10",
+    "Phoenix unemployment rate": "AZUR",
+    "construction spending": "TTLCONS",
+    "industrial production index": "INDPRO",
+}
+
+
+def _latest_value(series_id: str) -> str | None:
+    if not FRED_KEY:
+        return None
+    params = {
+        "series_id": series_id,
+        "api_key": FRED_KEY,
+        "file_type": "json",
+        "sort_order": "desc",
+        "limit": 5,
+    }
+    try:
+        r = requests.get(BASE, params=params, timeout=5)
+        if r.status_code != 200:
+            return None
+        for obs in r.json().get("observations", []):
+            if obs["value"] not in (".", "", None):
+                return f"{obs['value']} (as of {obs['date']})"
+        return None
+    except (requests.RequestException, ValueError, KeyError):
+        return None
+
+
+def fetch(submarket: str) -> list[dict]:
+    signals = []
+    for name, series_id in SERIES.items():
+        value = _latest_value(series_id)
+        if value is None:
+            signals.append(
+                {
+                    "name": name,
+                    "value": "unavailable",
+                    "source": "FRED (unavailable)",
+                }
+            )
+        else:
+            signals.append({"name": name, "value": value, "source": "FRED"})
+    return signals
+
+
+if __name__ == "__main__":
+    import json
+
+    print(json.dumps(fetch("Phoenix-Mesa-Chandler"), indent=2))


### PR DESCRIPTION
## Summary
- Implements `fetchers/fred.py` per PRD §6 (confirmed series IDs) and §7.1 (agreed signal name strings).
- `fred.fetch(submarket: str) -> list[dict]` returns 6 signals matching `{name, value, source}` shape.
- All values returned as strings (e.g. `"4.32 (as of 2026-04-25)"`).
- Graceful failure: missing key, non-200, network error, or empty observations all yield a signal with `value: "unavailable"` and `source: "FRED (unavailable)"`.

## Series wired (per merged PRD §6)
| Signal name (§7.1) | Series ID |
|---|---|
| `30-yr mortgage rate` | `MORTGAGE30US` |
| `federal funds rate` | `FEDFUNDS` |
| `10-yr Treasury yield` | `DGS10` |
| `Phoenix unemployment rate` | `AZUR` |
| `construction spending` | `TTLCONS` |
| `industrial production index` | `INDPRO` |

## One open question for the team
The §7.1 contract calls the signal `"Phoenix unemployment rate"` but the §6 confirmed series ID is `AZUR` (Arizona statewide). Phoenix MSA series `PHOE004URN` exists if we want the data to match the label exactly. Going with `AZUR` per §6 confirmation; happy to swap if Joel wants tighter precision before demo.

## Test plan
- [x] `python -m fetchers.fred` returns 6 signals with the §7.1 shape
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `python -m py_compile fetchers/fred.py` passes
- [x] `bandit -r . --exclude .venv -ll` no findings
- [ ] Smoke test with real `FRED_API_KEY` once PR review opens (need key in `.env`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)