### PR TITLE
docs: resolve §9 error handling and checkpoint decisions in PRD

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -156,7 +156,7 @@ Each fetcher returns a **list** of these dicts. Joel expects a list. Not a dict 
 
 - [x] **§6** — Confirm all FRED series IDs (Manny + team)
 - [x] **§7.1** — Agree on exact `name` strings for each signal (all fetcher owners + Joel)
-- [ ] **§7.2** — Confirm `signal_breakdown` in DealBrief is the same list shape as §7.1 (Joel + Victor)
+- [x] **§7.2** — Confirm `signal_breakdown` in DealBrief is the same list shape as §7.1 (Joel + Victor) — **Confirmed. Same shape: `{"name": str, "value": str, "source": str}`**
 - [x] What happens if a FRED series returns no data for the requested date range? — **Skip that signal and continue. Return `{"name": <name>, "value": "unavailable", "source": "FRED (unavailable)"}` for any missing series.**
 - [x] What happens if Tavily returns zero results? — **Skip news signals and continue. Return an empty list.**
 - [x] Does the human checkpoint accept only `yes` / `no` or any truthy input? — **`yes` / `no` only. Any other input re-prompts.**

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -157,6 +157,6 @@ Each fetcher returns a **list** of these dicts. Joel expects a list. Not a dict 
 - [x] **§6** — Confirm all FRED series IDs (Manny + team)
 - [x] **§7.1** — Agree on exact `name` strings for each signal (all fetcher owners + Joel)
 - [ ] **§7.2** — Confirm `signal_breakdown` in DealBrief is the same list shape as §7.1 (Joel + Victor)
-- [ ] What happens if a FRED series returns no data for the requested date range? (Manny to propose, team to agree)
-- [ ] What happens if Tavily returns zero results? (Michael to propose, team to agree)
-- [ ] Does the human checkpoint accept only `yes` / `no` or any truthy input? (Victor to decide)
+- [x] What happens if a FRED series returns no data for the requested date range? — **Skip that signal and continue. Return `{"name": <name>, "value": "unavailable", "source": "FRED (unavailable)"}` for any missing series.**
+- [x] What happens if Tavily returns zero results? — **Skip news signals and continue. Return an empty list.**
+- [x] Does the human checkpoint accept only `yes` / `no` or any truthy input? — **`yes` / `no` only. Any other input re-prompts.**


### PR DESCRIPTION
## Summary
- FRED no data → skip that signal, return `unavailable` entry, continue
- Tavily zero results → return empty list, continue
- Human checkpoint → `yes` / `no` only, re-prompt on anything else

All three decisions made by Victor as core loop owner. Marks §9 items as resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)