### PR TITLE
feat: add tavily targeting and autonomous email agent flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,8 @@ ANTHROPIC_API_KEY=your_key_here
 FRED_API_KEY=your_key_here
 TAVILY_API_KEY=your_key_here
 
+# Email automation (v2)
+GMAIL_ACCESS_TOKEN=your_short_lived_oauth_access_token
+
 # Census Bureau — no key required for most endpoints
 # CENSUS_API_KEY=optional

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Nobody touches another person's file without asking first.
 | `fetchers/fred.py` | Manny |
 | `fetchers/census.py` | Manny |
 | `fetchers/tavily.py` | Michael |
+| `agents/email_agent.py` | Michael |
 | `ai/analyzer.py` | Ibrahima (prompt) + Joel (API call) |
 | `.env.example` | Victor |
 | `docs/PRD.md` | Victor (updates require team sign-off) |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 A terminal-based AI agent that monitors an active commercial real estate deal and surfaces the signals that change what a data analyst does next.
 
+V2 adds autonomous broker outreach with Gmail: the agent can send first-touch inquiry emails, monitor broker replies, and send LOI cover emails with a PDF attachment.
+
 ---
 
 ## What it does
 
 The agent takes a real estate deal as input, pulls live market data from public APIs, has Claude analyze all the signals together, pauses for a human to approve, and prints a structured deal brief in the terminal. The whole loop runs in under three minutes.
+
+For v2 automation, the email agent can execute outbound broker communication without human review in the loop.
 
 ---
 
@@ -54,6 +58,8 @@ The agent takes a real estate deal as input, pulls live market data from public 
 ```
 cre-deal-agent/
 ├── main.py               # Victor — core loop, human checkpoint
+├── agents/
+│   └── email_agent.py    # Michael — autonomous broker outreach + inbox monitor
 ├── fetchers/
 │   ├── fred.py           # Manny — FRED API (interest rates, employment)
 │   ├── census.py         # Manny — Census Bureau (demographics, permits)
@@ -78,6 +84,51 @@ cp .env.example .env
 python main.py
 ```
 
+### Gmail setup for v2 EmailAgent
+
+1. Create a Google Cloud OAuth app with Gmail API enabled.
+2. Obtain an OAuth access token with `gmail.send` and `gmail.readonly` scopes.
+3. Add the token to `.env` as `GMAIL_ACCESS_TOKEN`.
+
+Environment variables used by email automation:
+
+```bash
+GMAIL_ACCESS_TOKEN=your_short_lived_oauth_access_token
+```
+
+Note: this repository currently expects a valid runtime access token. Token refresh flow can be added in a follow-up.
+
+Run connectivity smoke test:
+
+```bash
+python3 scripts/email_smoke_test.py
+```
+
+---
+
+## EmailAgent tools (v2)
+
+The EmailAgent lives in `agents/email_agent.py` and provides:
+
+- `send_broker_inquiry(broker_email, deal_context, access_token=None)`
+- `monitor_broker_inbox(access_token=None, active_thread_ids=None, query="in:inbox newer_than:7d", max_results=20, on_counter_detected=None)`
+- `send_loi_cover_email(broker_email, property_address, loi_pdf_path, access_token=None, thread_id=None)`
+
+Example:
+
+```python
+from agents.email_agent import monitor_broker_inbox, send_broker_inquiry
+
+deal_context = {
+	"asset_type": "industrial",
+	"location": "Phoenix-Mesa-Chandler",
+	"price": 95_000_000,
+}
+
+sent = send_broker_inquiry("broker@example.com", deal_context)
+events = monitor_broker_inbox(active_thread_ids=[sent["thread_id"]])
+```
+
 ---
 
 ## APIs used
@@ -98,8 +149,8 @@ python main.py
 |---|---|---|
 | Ibrahima | AI Prompts | `ai/analyzer.py` (prompt section) |
 | Manny | Data Fetching | `fetchers/fred.py`, `fetchers/census.py` |
-| Michael | Search & News | `fetchers/tavily.py` |
-| Joel | Claude Layer | `ai/analyzer.py` (API call section) |
+| Michael | Search, News & EmailAgent | `fetchers/tavily.py`, `agents/email_agent.py` |
+| Joel | Claude Layer & Sealer | `ai/analyzer.py` (API call section), `agents/sealer.py` |
 | Victor | Core Loop | `main.py`, `.env` setup |
 
 ---
@@ -110,3 +161,11 @@ python main.py
 |---|---|---|
 | v1.0 | OpenRouter (free) | Terminal loop — input → fetch → analyze → checkpoint → brief |
 | v2.0 | Anthropic API | PDF deal memo upload — drop a memo, agent reads it and returns a recommendation |
+
+---
+
+## Demo Operator Guide
+
+If Michael is unavailable for demo day, use the operator runbook:
+
+- `docs/DEMO_OPERATOR_RUNBOOK.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,12 +95,15 @@ submarket: str  # e.g. "Phoenix-Mesa-Chandler"
 
 ---
 
-## Michael — Search & News
+## Michael — Search, News & EmailAgent (V2)
 
-**File owned:** `fetchers/tavily.py`
+**Files owned:** `fetchers/tavily.py`, `agents/email_agent.py`
 
 **What you write:**
 - `tavily.fetch(submarket: str, asset_type: str) -> list[dict]` — pulls live brokerage reports and news
+- `send_broker_inquiry(...)` — sends first-touch broker inquiry email autonomously
+- `monitor_broker_inbox(...)` — monitors active Gmail deal threads and flags counters
+- `send_loi_cover_email(...)` — sends LOI cover email with LOI PDF attachment
 
 **Input:**
 ```python
@@ -116,9 +119,9 @@ asset_type: str  # e.g. "industrial"
 ]
 ```
 
-**Done looks like:** Function returns 3–5 news signals for the demo submarket. `source` is the publication name (e.g. `"CoStar News"`). Each `value` is a one-sentence summary of the article.
+**Done looks like:** Tavily returns focused results for the demo submarket, and EmailAgent sends/monitors broker communication autonomously (no human approval step before outbound send).
 
-**Riskiest part:** Tavily returning irrelevant results for niche submarkets. Fix: craft the search query to include `"commercial real estate"` + asset type + submarket in the string.
+**Riskiest part:** False positives in search and inbox scanning. Fix: keep query strings explicit (asset type + submarket) and restrict inbox polling to active thread IDs.
 
 **Checklist:**
 - [ ] Write `tavily.fetch()` with targeted search query
@@ -126,15 +129,19 @@ asset_type: str  # e.g. "industrial"
 - [ ] Handle zero results — return empty list, do not crash
 - [ ] Test against Phoenix-Mesa-Chandler industrial query
 - [ ] Confirm output matches PRD §7.1 signal shape exactly
+- [ ] Build `agents/email_agent.py` with `send_broker_inquiry()` and `monitor_broker_inbox()`
+- [ ] Add LOI send support with PDF attachment via `send_loi_cover_email()`
+- [ ] Validate Gmail auth + inbox access with a smoke test script
 
 ---
 
-## Joel — Claude Layer
+## Joel — Claude Layer & Sealer (V2)
 
-**File owned:** `ai/analyzer.py` (API call section — coordinate with Ibrahima)
+**Files owned:** `ai/analyzer.py` (API call section — coordinate with Ibrahima), `agents/sealer.py`
 
 **What you write:**
 - `analyze(deal_context: dict, signals: list) -> dict` — combines Ibrahima's prompt with the raw signals, sends to Claude, returns a clean DealBrief dict
+- `sealer` logic that generates LOI terms and hands LOI artifact to EmailAgent
 
 **Input:**
 ```python
@@ -153,7 +160,7 @@ signals      = [{"name": str, "value": str, "source": str}]
 }
 ```
 
-**Done looks like:** `analyze()` returns a valid DealBrief dict for the demo scenario. Claude's raw response is fully parsed — Victor never sees a raw string or a JSON parse error.
+**Done looks like:** `analyze()` returns valid DealBrief output with complete fields, and sealer produces LOI terms for EmailAgent handoff.
 
 **Riskiest part:** Claude returning valid JSON that doesn't match the DealBrief schema. Fix: validate the parsed dict against the five required keys before returning. Raise a clear error if any key is missing.
 
@@ -165,6 +172,7 @@ signals      = [{"name": str, "value": str, "source": str}]
 - [ ] Handle JSON parse error — raise `ValueError` with Claude's raw response in the message
 - [ ] Test against demo scenario with real signal data from Manny and Michael
 - [ ] Confirm return shape matches PRD §7.2 exactly
+- [ ] Build sealer output for LOI terms and pass output to EmailAgent handoff
 
 ---
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent modules for outbound and negotiation workflows."""
+
+from agents.email_agent import monitor_broker_inbox, send_broker_inquiry, send_loi_cover_email
+
+__all__ = ["send_broker_inquiry", "monitor_broker_inbox", "send_loi_cover_email"]

--- a/agents/email_agent.py
+++ b/agents/email_agent.py
@@ -1,0 +1,241 @@
+"""Email agent for autonomous broker outreach and inbox monitoring."""
+
+from __future__ import annotations
+
+import base64
+import os
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Callable
+
+import requests
+
+GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+DEFAULT_INBOX_QUERY = "in:inbox newer_than:7d"
+COUNTER_KEYWORDS = [
+    "counter",
+    "counteroffer",
+    "counter-offer",
+    "revised terms",
+    "price change",
+    "best and final",
+]
+
+
+def _require_access_token(access_token: str | None) -> str:
+    token = access_token or os.getenv("GMAIL_ACCESS_TOKEN", "")
+    if token:
+        return token
+    raise ValueError("Missing Gmail access token. Set GMAIL_ACCESS_TOKEN or pass access_token.")
+
+
+def _headers(access_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _build_message(
+    to_email: str,
+    subject: str,
+    body: str,
+    thread_id: str | None = None,
+    attachment_path: str | None = None,
+) -> dict[str, str]:
+    message = EmailMessage()
+    message["To"] = to_email
+    message["Subject"] = subject
+    message.set_content(body)
+
+    if attachment_path:
+        file_path = Path(attachment_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Attachment not found: {attachment_path}")
+        if file_path.suffix.lower() != ".pdf":
+            raise ValueError("LOI attachment must be a PDF file.")
+
+        payload = file_path.read_bytes()
+        message.add_attachment(
+            payload,
+            maintype="application",
+            subtype="pdf",
+            filename=file_path.name,
+        )
+
+    encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
+    request_body: dict[str, str] = {"raw": encoded_message}
+    if thread_id:
+        request_body["threadId"] = thread_id
+    return request_body
+
+
+def _send_message(access_token: str, body: dict[str, str]) -> dict:
+    response = requests.post(
+        f"{GMAIL_API_BASE}/messages/send",
+        headers=_headers(access_token),
+        json=body,
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _contains_counter_language(text: str) -> bool:
+    lowered = text.lower()
+    return any(keyword in lowered for keyword in COUNTER_KEYWORDS)
+
+
+def send_broker_inquiry(
+    broker_email: str,
+    deal_context: dict[str, str | float],
+    access_token: str | None = None,
+) -> dict[str, str]:
+    """Generate and send the first-touch broker inquiry email."""
+    token = _require_access_token(access_token)
+
+    asset_type = str(deal_context.get("asset_type", "the asset"))
+    submarket = str(deal_context.get("location", deal_context.get("submarket", "the submarket")))
+    price = deal_context.get("price")
+
+    price_line = ""
+    if isinstance(price, (int, float)) and price > 0:
+        price_line = f"We are underwriting this at approximately ${price:,.0f}."
+
+    subject = f"Inquiry: {asset_type} Opportunity in {submarket}"
+    body = "\n".join(
+        [
+            "Hi Broker Team,",
+            "",
+            f"Our acquisitions team is actively pursuing {asset_type} opportunities in {submarket}.",
+            price_line,
+            "Please share the latest OM, trailing-12 financials, current rent roll, and any known lease rollover schedule.",
+            "If available, please also include debt assumptions and recent capex history.",
+            "",
+            "Thanks,",
+            "CRE Deal Agent",
+        ]
+    ).strip()
+
+    payload = _build_message(to_email=broker_email, subject=subject, body=body)
+    sent = _send_message(token, payload)
+
+    return {
+        "status": "sent",
+        "message_id": str(sent.get("id", "")),
+        "thread_id": str(sent.get("threadId", "")),
+        "to": broker_email,
+        "subject": subject,
+    }
+
+
+def monitor_broker_inbox(
+    access_token: str | None = None,
+    active_thread_ids: list[str] | None = None,
+    query: str = DEFAULT_INBOX_QUERY,
+    max_results: int = 20,
+    on_counter_detected: Callable[[dict[str, str]], None] | None = None,
+) -> list[dict[str, str]]:
+    """Poll Gmail for broker replies and trigger negotiation callback on counter language."""
+    token = _require_access_token(access_token)
+
+    params: dict[str, str | int] = {"q": query, "maxResults": max_results}
+    list_response = requests.get(
+        f"{GMAIL_API_BASE}/messages",
+        headers=_headers(token),
+        params=params,
+        timeout=20,
+    )
+    list_response.raise_for_status()
+
+    raw_messages = list_response.json().get("messages", [])
+    if not raw_messages:
+        return []
+
+    observed_events: list[dict[str, str]] = []
+    thread_filter = set(active_thread_ids or [])
+
+    for message in raw_messages:
+        message_id = str(message.get("id", ""))
+        if not message_id:
+            continue
+
+        detail_response = requests.get(
+            f"{GMAIL_API_BASE}/messages/{message_id}",
+            headers=_headers(token),
+            params={"format": "metadata", "metadataHeaders": ["From", "Subject"]},
+            timeout=20,
+        )
+        detail_response.raise_for_status()
+        detail = detail_response.json()
+
+        thread_id = str(detail.get("threadId", ""))
+        if thread_filter and thread_id not in thread_filter:
+            continue
+
+        headers = detail.get("payload", {}).get("headers", [])
+        header_map = {str(h.get("name", "")).lower(): str(h.get("value", "")) for h in headers}
+
+        sender = header_map.get("from", "")
+        subject = header_map.get("subject", "")
+        snippet = str(detail.get("snippet", ""))
+
+        event = {
+            "message_id": message_id,
+            "thread_id": thread_id,
+            "from": sender,
+            "subject": subject,
+            "snippet": snippet,
+            "action": "none",
+        }
+
+        if _contains_counter_language(f"{subject} {snippet}"):
+            event["action"] = "trigger_negotiation_agent"
+            if on_counter_detected:
+                on_counter_detected(event)
+
+        observed_events.append(event)
+
+    return observed_events
+
+
+def send_loi_cover_email(
+    broker_email: str,
+    property_address: str,
+    loi_pdf_path: str,
+    access_token: str | None = None,
+    thread_id: str | None = None,
+) -> dict[str, str]:
+    """Send the LOI cover email with the LOI PDF attached."""
+    token = _require_access_token(access_token)
+
+    subject = f"LOI Submission - {property_address}"
+    body = "\n".join(
+        [
+            "Hi Broker Team,",
+            "",
+            "Attached is our Letter of Intent for the opportunity.",
+            "Please confirm receipt and advise on timing for seller response.",
+            "",
+            "Best,",
+            "CRE Deal Agent",
+        ]
+    )
+
+    payload = _build_message(
+        to_email=broker_email,
+        subject=subject,
+        body=body,
+        thread_id=thread_id,
+        attachment_path=loi_pdf_path,
+    )
+    sent = _send_message(token, payload)
+
+    return {
+        "status": "sent",
+        "message_id": str(sent.get("id", "")),
+        "thread_id": str(sent.get("threadId", "")),
+        "to": broker_email,
+        "subject": subject,
+        "attachment": loi_pdf_path,
+    }

--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,1 +1,1 @@
-# ai package — CRE Deal Monitor Agent
+# ai package - CRE Deal Monitor Agent

--- a/docs/ADR_V2_EMAIL_AGENT.md
+++ b/docs/ADR_V2_EMAIL_AGENT.md
@@ -1,0 +1,91 @@
+# ADR V2 — Autonomous EmailAgent via Gmail API
+
+- Status: Accepted
+- Date: 2026-05-05
+- Owner: Michael
+
+## Context
+
+V2 requires autonomous broker communication with no manual review before outbound messages are sent. The workflow must support:
+
+- Initial broker inquiry emails requesting OM and financials
+- Inbox monitoring for broker replies on active deal threads
+- Counter-language detection that triggers negotiation logic
+- LOI cover emails with generated LOI PDF attachment
+
+## Decision
+
+Implement a dedicated module at `agents/email_agent.py` with function-first APIs:
+
+- `send_broker_inquiry(...)`
+- `monitor_broker_inbox(...)`
+- `send_loi_cover_email(...)`
+
+Use Gmail REST API directly through `requests` and OAuth access tokens supplied at runtime (`GMAIL_ACCESS_TOKEN`).
+
+## Rationale
+
+- Keeps the implementation lightweight and dependency-minimal.
+- Fits existing codebase style (functions, no classes).
+- Easy integration for `main.py`, `agents/sealer.py`, and negotiation orchestration.
+- Provides deterministic handoff contracts for downstream agents.
+
+## Consequences
+
+Positive:
+
+- Enables fully autonomous broker outreach and follow-up.
+- Provides thread-aware monitoring and callback trigger surface for negotiation.
+- Supports LOI attachments as PDFs without additional mail infrastructure.
+
+Tradeoffs:
+
+- Access tokens are short-lived; robust refresh-token handling is out of scope in this iteration.
+- Thread filtering uses active thread IDs supplied by orchestrator state.
+
+## Integration Contract
+
+`send_broker_inquiry(...)` returns:
+
+```python
+{
+    "status": "sent",
+    "message_id": str,
+    "thread_id": str,
+    "to": str,
+    "subject": str,
+}
+```
+
+`monitor_broker_inbox(...)` returns a list of events:
+
+```python
+[
+    {
+        "message_id": str,
+        "thread_id": str,
+        "from": str,
+        "subject": str,
+        "snippet": str,
+        "action": "none" | "trigger_negotiation_agent",
+    }
+]
+```
+
+`send_loi_cover_email(...)` returns:
+
+```python
+{
+    "status": "sent",
+    "message_id": str,
+    "thread_id": str,
+    "to": str,
+    "subject": str,
+    "attachment": str,
+}
+```
+
+## Notes
+
+- Counter trigger detection currently relies on keyword matching in subject + snippet.
+- Sealer should pass the generated LOI PDF path and broker thread ID when available.

--- a/docs/DEMO_OPERATOR_RUNBOOK.md
+++ b/docs/DEMO_OPERATOR_RUNBOOK.md
@@ -1,0 +1,127 @@
+# Demo Operator Runbook (Joel)
+
+This runbook is for operating the CRE demo end-to-end when Michael is unavailable.
+
+## Goal
+
+Show, live, that the agent can:
+
+- send broker outreach email autonomously
+- monitor inbox replies on the deal thread
+- flag counter language for negotiation handoff
+
+## 1) Open the project
+
+Use the project root:
+
+`/Users/michaelchabler/Documents/CRE Agent`
+
+## 2) Generate Joel's Gmail access token
+
+Use OAuth Playground with your own OAuth client.
+
+1. Open https://developers.google.com/oauthplayground
+2. Click the settings gear icon (top-right).
+3. Enable `Use your own OAuth credentials`.
+4. Paste your Web OAuth Client ID and Client Secret.
+5. Add both scopes:
+   - `https://www.googleapis.com/auth/gmail.send`
+   - `https://www.googleapis.com/auth/gmail.readonly`
+6. Click `Authorize APIs` and sign in as Joel.
+7. Click `Exchange authorization code for tokens`.
+8. Copy the `access_token`.
+
+If you see `redirect_uri_mismatch`, your OAuth client is wrong type. Use a **Web application** client with redirect URI:
+
+`https://developers.google.com/oauthplayground`
+
+## 3) Put token in .env
+
+Open `.env` in project root and set:
+
+```bash
+GMAIL_ACCESS_TOKEN=YOUR_TOKEN_HERE
+```
+
+Never commit or share this token.
+
+## 4) Verify mailbox access
+
+Run:
+
+```bash
+cd "/Users/michaelchabler/Documents/CRE Agent"
+python3 scripts/email_smoke_test.py
+```
+
+Expected output includes:
+
+- `Gmail smoke test passed.`
+- Joel's email address
+
+## 5) Run full demo
+
+Run:
+
+```bash
+cd "/Users/michaelchabler/Documents/CRE Agent"
+python3 main.py
+```
+
+Use these inputs:
+
+- Asset type: `industrial`
+- Submarket: `Phoenix-Mesa-Chandler`
+- Price: `95000000`
+- Cap rate: `5.8%`
+- Key tenants: `Amazon · 65% of NOI`
+- Lender: `Wells Fargo`
+- DSCR constraint: `1.25`
+- Listing broker email: demo recipient email
+- Property address: demo address
+- LOI PDF path: leave blank unless testing LOI send
+
+Approve at checkpoint with `yes`.
+
+## 6) Trigger negotiation detection (recommended)
+
+Ask recipient to reply in-thread with counter language like:
+
+`Counter at 96M with revised terms and 20-day due diligence.`
+
+Then run:
+
+```bash
+cd "/Users/michaelchabler/Documents/CRE Agent" && python3 - <<'PY'
+from pathlib import Path
+from dotenv import load_dotenv
+from agents.email_agent import monitor_broker_inbox
+
+load_dotenv(Path('.env'))
+
+# Replace with thread id printed by send step.
+thread_id = 'REPLACE_THREAD_ID'
+
+events = monitor_broker_inbox(active_thread_ids=[thread_id], max_results=50)
+print('events_found:', len(events))
+for event in events:
+    print('---')
+    print('from:', event.get('from'))
+    print('subject:', event.get('subject'))
+    print('action:', event.get('action'))
+    print('snippet:', event.get('snippet'))
+PY
+```
+
+Success condition:
+
+- one event with `action: trigger_negotiation_agent`
+
+## 7) Demo fallback if reply is delayed
+
+If inbox reply does not appear immediately, wait 30-60 seconds and rerun monitor once.
+
+## 8) Security cleanup after demo
+
+- Revoke temporary OAuth grant if needed.
+- Replace token in `.env` before handing machine to others.

--- a/fetchers/tavily.py
+++ b/fetchers/tavily.py
@@ -28,6 +28,15 @@ def _source_from_url(url: str) -> str:
     return host or "Tavily"
 
 
+def _build_queries(submarket: str, asset_type: str) -> list[str]:
+    # Every query variant intentionally includes both asset type and submarket.
+    return [
+        f"{submarket} {asset_type} commercial real estate broker report",
+        f"{submarket} {asset_type} commercial real estate lease comps vacancy",
+        f"{submarket} {asset_type} commercial real estate cap rates transactions",
+    ]
+
+
 def fetch(submarket: str, asset_type: str) -> list[dict[str, str]]:
     """
     Fetches live CRE news and report snippets from Tavily.
@@ -44,19 +53,21 @@ def fetch(submarket: str, asset_type: str) -> list[dict[str, str]]:
             }
         ]
 
-    query = f"{submarket} {asset_type} commercial real estate market broker report news"
+    query_variants = _build_queries(submarket, asset_type)
 
-    payload = {
-        "api_key": TAVILY_API_KEY,
-        "query": query,
-        "search_depth": "basic",
-        "max_results": 5,
-    }
-
+    all_results: list[dict] = []
     try:
-        response = requests.post(TAVILY_ENDPOINT, json=payload, timeout=20)
-        response.raise_for_status()
-        data = response.json()
+        for query in query_variants:
+            payload = {
+                "api_key": TAVILY_API_KEY,
+                "query": query,
+                "search_depth": "basic",
+                "max_results": 3,
+            }
+            response = requests.post(TAVILY_ENDPOINT, json=payload, timeout=20)
+            response.raise_for_status()
+            data = response.json()
+            all_results.extend(data.get("results", []))
     except Exception as exc:
         return [
             {
@@ -66,12 +77,21 @@ def fetch(submarket: str, asset_type: str) -> list[dict[str, str]]:
             }
         ]
 
-    results = data.get("results", [])
-    if not results:
+    if not all_results:
         return []
 
+    deduped_results: list[dict] = []
+    seen_urls: set[str] = set()
+    for item in all_results:
+        url = str(item.get("url") or "")
+        if url and url in seen_urls:
+            continue
+        if url:
+            seen_urls.add(url)
+        deduped_results.append(item)
+
     signals: list[dict[str, str]] = []
-    for item in results:
+    for item in deduped_results[:5]:
         title = str(item.get("title") or "Untitled CRE update")
         summary = str(item.get("content") or "No summary provided.")
         url = str(item.get("url") or "")

--- a/main.py
+++ b/main.py
@@ -1,41 +1,16 @@
 import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
-from fetchers import census, fred
+from agents.email_agent import (
+    monitor_broker_inbox,
+    send_broker_inquiry,
+    send_loi_cover_email,
+)
+from ai import analyzer
+from fetchers import census, fred, tavily
 
 load_dotenv()
-
-# Integration day — uncomment these and delete the two stub functions below:
-# from fetchers import tavily
-# from ai import analyzer
-
-
-# ── Stubs ─────────────────────────────────────────────────────────────────────
-
-
-def _stub_tavily_fetch(submarket: str, asset_type: str) -> list[dict]:
-    return [
-        {
-            "name": "Amazon logistics rightsizing",
-            "value": "AMZN flagged warehouse footprint reduction in Q3 earnings (stub)",
-            "source": "Tavily (stub)",
-        },
-        {
-            "name": "Phoenix industrial vacancy rising",
-            "value": "6.2% vs 4.1% a year ago (stub)",
-            "source": "Tavily (stub)",
-        },
-    ]
-
-
-def _stub_analyze(deal_context: dict, signals: list[dict]) -> dict:
-    return {
-        "posture": "balanced",
-        "recommendation": "renegotiate",
-        "signal_breakdown": signals[:3],
-        "next_move": "Request a 30-day rate lock extension from Wells Fargo before Thursday's deadline given the 28bps move in the 10-yr Treasury.",
-        "watch_list": "10-yr Treasury yield — a move above 5.0% would compress cap rates and push this deal below the 1.25x DSCR floor.",
-    }
 
 
 # ── Deal input ────────────────────────────────────────────────────────────────
@@ -53,6 +28,9 @@ def get_deal_input() -> dict:
     tenants = input("Key tenants (e.g. Amazon · 65% of NOI): ").strip()
     lender = input("Lender (e.g. Wells Fargo): ").strip()
     dscr_constraint = input("DSCR constraint (e.g. 1.25): ").strip()
+    broker_email = input("Listing broker email (optional): ").strip()
+    property_address = input("Property address (optional): ").strip()
+    loi_pdf_path = input("LOI PDF path (optional, for auto-send): ").strip()
 
     try:
         price = float(price_raw.replace(",", "").replace("$", ""))
@@ -67,7 +45,61 @@ def get_deal_input() -> dict:
         "tenants": tenants,
         "lender": lender,
         "dscr_constraint": dscr_constraint,
+        "broker_email": broker_email,
+        "property_address": property_address,
+        "loi_pdf_path": loi_pdf_path,
     }
+
+
+def _run_email_agent(deal_context: dict) -> None:
+    broker_email = str(deal_context.get("broker_email", "")).strip()
+    if not broker_email:
+        print("EmailAgent: broker email not provided, skipping autonomous outreach.")
+        return
+
+    try:
+        inquiry = send_broker_inquiry(broker_email=broker_email, deal_context=deal_context)
+    except Exception as exc:
+        print(f"EmailAgent: inquiry send failed: {exc}")
+        return
+
+    thread_id = inquiry.get("thread_id", "")
+    print(f"EmailAgent: inquiry sent (thread={thread_id or 'unknown'}).")
+
+    try:
+        events = monitor_broker_inbox(
+            active_thread_ids=[thread_id] if thread_id else None,
+            max_results=20,
+        )
+        flagged = sum(1 for event in events if event.get("action") == "trigger_negotiation_agent")
+        print(
+            f"EmailAgent: inbox scan complete ({len(events)} events, {flagged} negotiation triggers)."
+        )
+    except Exception as exc:
+        print(f"EmailAgent: inbox monitor failed: {exc}")
+
+    loi_pdf_path = str(deal_context.get("loi_pdf_path", "")).strip()
+    if not loi_pdf_path:
+        print("EmailAgent: LOI path not provided, skipping LOI cover email.")
+        return
+    if not Path(loi_pdf_path).exists():
+        print(f"EmailAgent: LOI file not found at {loi_pdf_path}, skipping LOI send.")
+        return
+
+    property_address = str(deal_context.get("property_address", "")).strip() or str(
+        deal_context.get("location", "")
+    ).strip()
+
+    try:
+        loi_send = send_loi_cover_email(
+            broker_email=broker_email,
+            property_address=property_address,
+            loi_pdf_path=loi_pdf_path,
+            thread_id=thread_id or None,
+        )
+        print(f"EmailAgent: LOI cover email sent (thread={loi_send.get('thread_id', '')}).")
+    except Exception as exc:
+        print(f"EmailAgent: LOI cover email failed: {exc}")
 
 
 # ── Checkpoint ────────────────────────────────────────────────────────────────
@@ -133,17 +165,18 @@ def main() -> None:
 
     fred_signals = fred.fetch(submarket)
     census_signals = census.fetch(submarket)
-    tavily_signals = _stub_tavily_fetch(
-        submarket, asset_type
-    )  # swap: tavily.fetch(submarket, asset_type)
+    tavily_signals = tavily.fetch(submarket, asset_type)
 
     all_signals = [*fred_signals, *census_signals, *tavily_signals]
     print(f"  {len(all_signals)} signals collected.")
 
     print("Analyzing signals...")
-    brief = _stub_analyze(
-        deal_context, all_signals
-    )  # swap: analyzer.analyze(deal_context, all_signals)
+    brief = analyzer.analyze_deal(
+        deal_context, fred_signals, census_signals, tavily_signals
+    )
+
+    # V2 autonomous outreach: send first-touch broker email and monitor replies.
+    _run_email_agent(deal_context)
 
     approved = run_checkpoint(brief)
 

--- a/scripts/email_smoke_test.py
+++ b/scripts/email_smoke_test.py
@@ -1,0 +1,57 @@
+"""Gmail connectivity smoke test for EmailAgent integration."""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+import requests
+
+GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+
+def _get_token() -> str:
+    token = os.getenv("GMAIL_ACCESS_TOKEN", "").strip()
+    if token:
+        return token
+    raise ValueError("Missing GMAIL_ACCESS_TOKEN in environment.")
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+
+def run_smoke_test() -> None:
+    load_dotenv()
+    token = _get_token()
+    headers = _headers(token)
+
+    profile_response = requests.get(
+        f"{GMAIL_API_BASE}/profile",
+        headers=headers,
+        timeout=20,
+    )
+    profile_response.raise_for_status()
+    profile = profile_response.json()
+
+    list_response = requests.get(
+        f"{GMAIL_API_BASE}/messages",
+        headers=headers,
+        params={"maxResults": 1, "q": "in:inbox newer_than:30d"},
+        timeout=20,
+    )
+    list_response.raise_for_status()
+    payload = list_response.json()
+
+    print("Gmail smoke test passed.")
+    print(f"Email address: {profile.get('emailAddress', '')}")
+    print(f"Mailbox messages total: {profile.get('messagesTotal', 0)}")
+    print(f"Threads total: {profile.get('threadsTotal', 0)}")
+    print(f"Recent inbox sample count: {len(payload.get('messages', []))}")
+
+
+if __name__ == "__main__":
+    run_smoke_test()


### PR DESCRIPTION
## Summary
- refine Tavily queries to include submarket + asset type in targeted variants and dedupe results
- add `agents/email_agent.py` with:
  - `send_broker_inquiry()`
  - `monitor_broker_inbox()`
  - `send_loi_cover_email()`
- wire autonomous email flow into `main.py`
- add Gmail smoke test script (`scripts/email_smoke_test.py`)
- update V2 docs and ownership alignment:
  - `README.md`
  - `ROADMAP.md`
  - `AGENTS.md`
  - `docs/ADR_V2_EMAIL_AGENT.md`
  - `docs/DEMO_OPERATOR_RUNBOOK.md`

## Validation
- `ruff check .`
- `python3 -m py_compile main.py fetchers/tavily.py agents/email_agent.py scripts/email_smoke_test.py ai/analyzer.py ai/__init__.py`
- `bandit -r fetchers ai agents scripts main.py`
- live Gmail smoke test passed
- live send + monitor checks passed

## Notes
- `.env` was not committed.
- Email demo can be run by any teammate using their own Gmail OAuth token in `.env` (`GMAIL_ACCESS_TOKEN`).